### PR TITLE
Use more specific vendor path to prevent issues with other autoloaders in the include path

### DIFF
--- a/core/components/resizer/model/resizer.class.php
+++ b/core/components/resizer/model/resizer.class.php
@@ -19,7 +19,7 @@
  * Place, Suite 330, Boston, MA 02111-1307 USA
  **/
 
-require 'vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 use Reductionist\Reductionist;
 


### PR DESCRIPTION
[See discussion in slack](http://logs.modx.org/%23general/2017-03-05.log) - if another vendor dir exists in the servers' include path, it uses that, causing odd stuff to happen. By making it look for the specific path, that problem is fixed.